### PR TITLE
AesCtrDecryptor: Move TEE_crypto_init() call into AesCtrDecryptor obj…

### DIFF
--- a/AesCtrDecryptor.cpp
+++ b/AesCtrDecryptor.cpp
@@ -76,7 +76,7 @@ android::status_t AesCtrDecryptor::decrypt(const android::Vector<uint8_t>& key,
         if (subSample.mNumBytesOfClearData > 0) {
 #ifdef USE_AES_TA
 	  if (secure)
-	    TEE_copy_secure_memory(destination, source,
+	    TEE_copy_secure_memory(source, destination,
 				   subSample.mNumBytesOfClearData, offset);
 	  else
 #endif

--- a/AesCtrDecryptor.cpp
+++ b/AesCtrDecryptor.cpp
@@ -38,6 +38,18 @@ namespace clearkeydrm {
 
 static const size_t kBlockBitCount = kBlockSize * 8;
 
+AesCtrDecryptor::AesCtrDecryptor() {
+#ifdef USE_AES_TA
+  TEE_crypto_init();
+#endif
+}
+
+AesCtrDecryptor::~AesCtrDecryptor() {
+#ifdef USE_AES_TA
+  TEE_crypto_close();
+#endif
+}
+
 android::status_t AesCtrDecryptor::decrypt(const android::Vector<uint8_t>& key,
         const Iv iv, const uint8_t* source,
         uint8_t* destination,

--- a/AesCtrDecryptor.cpp
+++ b/AesCtrDecryptor.cpp
@@ -43,7 +43,8 @@ android::status_t AesCtrDecryptor::decrypt(const android::Vector<uint8_t>& key,
         uint8_t* destination,
         const SubSample* subSamples,
         size_t numSubSamples,
-        size_t* bytesDecryptedOut) {
+	size_t* bytesDecryptedOut,
+	bool secure) {
     uint32_t blockOffset = 0;
     uint8_t previousEncryptedCounter[kBlockSize];
     memset(previousEncryptedCounter, 0, kBlockSize);
@@ -61,8 +62,15 @@ android::status_t AesCtrDecryptor::decrypt(const android::Vector<uint8_t>& key,
         const SubSample& subSample = subSamples[i];
 
         if (subSample.mNumBytesOfClearData > 0) {
+#ifdef USE_AES_TA
+	  if (secure)
+	    TEE_copy_secure_memory(destination, source,
+				   subSample.mNumBytesOfClearData, offset);
+	  else
+#endif
             memcpy(destination + offset, source + offset,
                     subSample.mNumBytesOfClearData);
+
             offset += subSample.mNumBytesOfClearData;
         }
 
@@ -73,10 +81,10 @@ android::status_t AesCtrDecryptor::decrypt(const android::Vector<uint8_t>& key,
                     opensslIv, previousEncryptedCounter,
                     &blockOffset);
 #else
-            TEE_AES_ctr128_encrypt(source + offset, destination + offset,
+            TEE_AES_ctr128_encrypt(source, destination,
                     subSample.mNumBytesOfEncryptedData, (const char*)key.array(),
                     opensslIv, previousEncryptedCounter,
-                    &blockOffset);
+		    &blockOffset, offset, secure);
 #endif
             offset += subSample.mNumBytesOfEncryptedData;
         }

--- a/AesCtrDecryptor.h
+++ b/AesCtrDecryptor.h
@@ -33,7 +33,7 @@ public:
     android::status_t decrypt(const android::Vector<uint8_t>& key, const Iv iv,
             const uint8_t* source, uint8_t* destination,
             const SubSample* subSamples, size_t numSubSamples,
-            size_t* bytesDecryptedOut);
+	    size_t* bytesDecryptedOut, bool secure);
 
 private:
     DISALLOW_EVIL_CONSTRUCTORS(AesCtrDecryptor);

--- a/AesCtrDecryptor.h
+++ b/AesCtrDecryptor.h
@@ -28,7 +28,8 @@ namespace clearkeydrm {
 
 class AesCtrDecryptor {
 public:
-    AesCtrDecryptor() {}
+    AesCtrDecryptor();
+    ~AesCtrDecryptor();
 
     android::status_t decrypt(const android::Vector<uint8_t>& key, const Iv iv,
             const uint8_t* source, uint8_t* destination,

--- a/ClearKeyUUID.cpp
+++ b/ClearKeyUUID.cpp
@@ -21,12 +21,19 @@
 namespace clearkeydrm {
 
 bool isClearKeyUUID(const uint8_t uuid[16]) {
-    static const uint8_t kClearKeyUUID[16] = {
+    static const uint8_t kCommonPsshBoxUUID[16] = {
         0x10,0x77,0xEF,0xEC,0xC0,0xB2,0x4D,0x02,
         0xAC,0xE3,0x3C,0x1E,0x52,0xE2,0xFB,0x4B
     };
 
-    return !memcmp(uuid, kClearKeyUUID, sizeof(kClearKeyUUID));
+    // To be used in mpd to specify drm scheme for players
+    static const uint8_t kClearKeyUUID[16] = {
+        0xE2,0x71,0x9D,0x58,0xA9,0x85,0xB3,0xC9,
+        0x78,0x1A,0xB0,0x30,0xAF,0x78,0xD3,0x0E
+    };
+
+    return !memcmp(uuid, kCommonPsshBoxUUID, sizeof(kCommonPsshBoxUUID)) ||
+           !memcmp(uuid, kClearKeyUUID, sizeof(kClearKeyUUID));
 }
 
 } // namespace clearkeydrm

--- a/CryptoPlugin.cpp
+++ b/CryptoPlugin.cpp
@@ -64,8 +64,8 @@ ssize_t CryptoPlugin::decrypt(bool secure, const KeyId keyId, const Iv iv,
                        reinterpret_cast<const uint8_t*>(srcPtr) + offset,
                        subSample.mNumBytesOfClearData);
 	      else
-		TEE_copy_secure_memory(reinterpret_cast<const uint8_t*>(dstPtr),
-				       reinterpret_cast<const uint8_t*>(srcPtr),
+		TEE_copy_secure_memory(reinterpret_cast<const uint8_t*>(srcPtr),
+				       reinterpret_cast<uint8_t*>(dstPtr),
 				       subSample.mNumBytesOfClearData, offset);
 
 	      offset += subSample.mNumBytesOfClearData;

--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ https://github.com/linaro-swg/optee_android_manifest
 
 ## Notes
 
+   make rule to rebuild OPTEE ClearKey mediadrm plugin
+```bash
+   make libdrmclearkeyopteeplugin
+```
+   make rule to rebuild OPTEE ClearKey TA
+```bash
+   make 442ed209-b8e2-405e-83845cc78c753428.ta
+```

--- a/Session.cpp
+++ b/Session.cpp
@@ -64,7 +64,7 @@ status_t Session::provideKeyResponse(const Vector<uint8_t>& response) {
 status_t Session::decrypt(
         const KeyId keyId, const Iv iv, const void* source,
         void* destination, const SubSample* subSamples,
-        size_t numSubSamples, size_t* bytesDecryptedOut) {
+        size_t numSubSamples, size_t* bytesDecryptedOut, bool secure) {
     Mutex::Autolock lock(mMapLock);
 
     Vector<uint8_t> keyIdVector;
@@ -79,7 +79,7 @@ status_t Session::decrypt(
             key, iv,
             reinterpret_cast<const uint8_t*>(source),
             reinterpret_cast<uint8_t*>(destination), subSamples,
-            numSubSamples, bytesDecryptedOut);
+            numSubSamples, bytesDecryptedOut, secure);
 }
 
 } // namespace clearkeydrm

--- a/Session.h
+++ b/Session.h
@@ -48,7 +48,7 @@ public:
     android::status_t decrypt(
             const KeyId keyId, const Iv iv, const void* source,
             void* destination, const SubSample* subSamples,
-            size_t numSubSamples, size_t* bytesDecryptedOut);
+            size_t numSubSamples, size_t* bytesDecryptedOut, bool secure);
 
 private:
     DISALLOW_EVIL_CONSTRUCTORS(Session);

--- a/SessionLibrary.cpp
+++ b/SessionLibrary.cpp
@@ -63,10 +63,6 @@ sp<Session> SessionLibrary::createSession() {
 
     mSessions.add(sessionId, new Session(sessionId));
 
-#ifdef USE_AES_TA
-        TEE_crypto_init();
-        ALOGD("%s:Session created.", __func__);
-#endif
     return mSessions.valueFor(sessionId);
 }
 
@@ -82,12 +78,6 @@ sp<Session> SessionLibrary::findSession(
 void SessionLibrary::destroySession(const sp<Session>& session) {
     Mutex::Autolock lock(mSessionsLock);\
     mSessions.removeItem(session->sessionId());
-#ifdef USE_AES_TA
-    TEE_crypto_close();
-    ALOGD("%s:Session destroy.", __func__);
-#endif
-
-
 }
 
 } // namespace clearkeydrm

--- a/SessionLibrary.cpp
+++ b/SessionLibrary.cpp
@@ -44,7 +44,7 @@ SessionLibrary* SessionLibrary::get() {
     Mutex::Autolock lock(sSingletonLock);
 
     if (sSingleton == NULL) {
-        ALOGD("Instantiating Session Library Singleton.");
+        ALOGD("Instantiating Session Library Singleton ClearKeyOPTEE Plugin.");
         sSingleton = new SessionLibrary();
     }
 

--- a/tests/AesCtrDecryptorUnittest.cpp
+++ b/tests/AesCtrDecryptorUnittest.cpp
@@ -38,7 +38,7 @@ class AesCtrDecryptorTest : public ::testing::Test {
 
         AesCtrDecryptor decryptor;
         return decryptor.decrypt(keyVector, iv, source, destination, subSamples,
-                                 numSubSamples, bytesDecryptedOut);
+                                 numSubSamples, bytesDecryptedOut, 0);
     }
 
     template <size_t totalSize>


### PR DESCRIPTION
…ect.

TEE_crypto_init() allocates memory for IV and key currently.
It is linked to the lifetime of the AES decryptor object
so makes no sense to be called from SessionLibrary object.

Also this change allows the AesCtrDecryptorUnitTests to be run
without any modification making maintaiing the OPTEE ClearKey
and rebasing to new versions of AOSP easier.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>